### PR TITLE
add #ifdef __APPLE__ to make compilable on OSX

### DIFF
--- a/sycl-gtx/include/SYCL/detail/common.h
+++ b/sycl-gtx/include/SYCL/detail/common.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #define CL_USE_DEPRECATED_OPENCL_1_2_APIS
+#ifdef __APPLE__
+#include <OpenCL/cl.h>
+#else
 #include <CL/cl.h>
-
+#endif
 #include "SYCL/detail/msvc_version.h"
 
 #include <cstdio>

--- a/sycl-gtx/include/SYCL/info.h
+++ b/sycl-gtx/include/SYCL/info.h
@@ -3,7 +3,11 @@
 // C. Interface of Memory Object Information Descriptors
 
 #define CL_USE_DEPRECATED_OPENCL_1_2_APIS
+#ifdef __APPLE__
+#include <OpenCL/cl.h>
+#else
 #include <CL/cl.h>
+#endif
 #include <type_traits>
 
 namespace cl {


### PR DESCRIPTION
I've added an #ifdef to make it possible to compile on OSX using a gcc from homebrew. 