### PR TITLE
missing cmath header for float abs. call was 'ambiguous' on OSX accor…

### DIFF
--- a/sycl-gtx/include/SYCL/detail/debug.h
+++ b/sycl-gtx/include/SYCL/detail/debug.h
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <cmath>
 
 #if MSVC_2013_OR_LOWER
 #define __func__ __FUNCTION__


### PR DESCRIPTION
…ding to gcc without this include.hopefully this doesn't break any other platforms

This is to fix the compiling of the work_efficient_prefix_sum test on OSX. A lot of the tests fail but at least they compile and run.