### PR TITLE
Generate 3D buffer index

### DIFF
--- a/sycl-gtx/include/SYCL/detail/src_handlers/invoke_source.h
+++ b/sycl-gtx/include/SYCL/detail/src_handlers/invoke_source.h
@@ -56,8 +56,12 @@ struct identifier_code {
         source::add(string_class("const int ") + name + " = " + name + "1 * " +
                     function_name + "(0) + " + name + "0");
       }
+      if (dimensions == 3) {
+        source::add(string_class("const int ") + name + " = " + name + "2 * " +
+                    function_name + "(1) * " + function_name + "(0) + " + name +
+                    "1 * " + function_name + "(0) + " + name + "0");
+      }
 
-      // TODO(progtx): 3d
     }
   }
 };


### PR DESCRIPTION
Generate the index to access a 3 dimensional buffer in the kernel. Generated line:
```
const int _sycl_gid = _sycl_gid2 * get_global_size(1) * get_global_size(0) + _sycl_gid1 * get_global_size(0) + _sycl_gid0;
```